### PR TITLE
Added adfDashboardEditsCancelled broadcast message to cancelEditMode()

### DIFF
--- a/dist/angular-dashboard-framework.js
+++ b/dist/angular-dashboard-framework.js
@@ -476,6 +476,7 @@ angular.module('adf')
         $scope.cancelEditMode = function(){
           $scope.editMode = false;
           $scope.modelCopy = angular.copy($scope.modelCopy, $scope.adfModel);
+          $rootScope.$broadcast('adfDashboardEditsCancelled');
         };
 
         // edit dashboard settings

--- a/src/scripts/dashboard.js
+++ b/src/scripts/dashboard.js
@@ -262,6 +262,7 @@ angular.module('adf')
         $scope.cancelEditMode = function(){
           $scope.editMode = false;
           $scope.modelCopy = angular.copy($scope.modelCopy, $scope.adfModel);
+          $rootScope.$broadcast('adfDashboardEditsCancelled');
         };
 
         // edit dashboard settings


### PR DESCRIPTION
Hi - I have an issue in a project I'm working on that requires an 'edits cancelled' message to be broadcast from cancelEditMode() to refresh the dashboard. Could you please merge this into your next release? 

Thanks!
Chris Hambleton