### PR TITLE
delete widget in adf

### DIFF
--- a/sample/partials/custom-widget-title.html
+++ b/sample/partials/custom-widget-title.html
@@ -17,7 +17,7 @@
      <i class="glyphicon glyphicon-fullscreen"></i>
    </a>
     <!-- remove widget -->
-    <a href="" title="remove widget" ng-click="close()" ng-if="editMode">
+    <a href="" title="remove widget" ng-click="remove()" ng-if="editMode">
       <i class="glyphicon glyphicon-remove"></i>
     </a>
   </span>

--- a/sample/partials/sampleWithFilter.html
+++ b/sample/partials/sampleWithFilter.html
@@ -1,1 +1,1 @@
-<adf-dashboard name="{{name}}" structure="4-8" adf-model="model" adf-widget-filter="widgetFilter" />
+<adf-dashboard name="{{name}}"  collapsible="{{collapsible}}" enableConfirmDelete={{enableConfirmDelete}} structure="4-8" adf-model="model" adf-widget-filter="widgetFilter" />

--- a/sample/scripts/sample-03.js
+++ b/sample/scripts/sample-03.js
@@ -62,6 +62,7 @@ angular.module('sample-03', ['adf', 'LocalStorageModule'])
   $scope.model = model;
   $scope.collapsible = false;
   $scope.maximizable = false;
+  $scope.enableConfirmDelete = true;
 
   // only allow github widgets
   $scope.widgetFilter = function(widget, type){

--- a/src/scripts/dashboard.js
+++ b/src/scripts/dashboard.js
@@ -340,6 +340,7 @@ angular.module('adf')
         var options = {
           name: $attr.name,
           editable: true,
+          enableConfirmDelete: stringToBoolean($attr.enableconfirmdelete),
           maximizable: stringToBoolean($attr.maximizable),
           collapsible: stringToBoolean($attr.collapsible)
         };

--- a/src/scripts/widget.js
+++ b/src/scripts/widget.js
@@ -80,7 +80,19 @@ angular.module('adf')
       var definition = $scope.definition;
       if (definition) {
         // bind close function
-        $scope.close = function() {
+
+      var deleteWidget = function(){
+        var column = $scope.col;
+        if (column) {
+          var index = column.widgets.indexOf(definition);
+          if (index >= 0) {
+            column.widgets.splice(index, 1);
+          }
+        }
+        $element.remove();
+      }
+        $scope.remove = function() {
+          if($scope.options.enableConfirmDelete){
               var deleteScope= $scope.$new();
               var adfDeleteTemplatePath = adfTemplatePath + 'widget-delete.html';
               if (definition.deleteTemplateUrl) {
@@ -98,17 +110,13 @@ angular.module('adf')
                 deleteScope.$destroy();
               };
               deleteScope.deleteDialog = function() {
-                instance.close();
-                deleteScope.$destroy();
-                var column = $scope.col;
-                if (column) {
-                  var index = column.widgets.indexOf(definition);
-                  if (index >= 0) {
-                    column.widgets.splice(index, 1);
-                  }
-                }
-                $element.remove();
+                deleteWidget();
+                deleteScope.closeDialog();
               };
+          }
+          else {
+              deleteWidget();
+          }
         }
 
         // bind reload function

--- a/src/scripts/widget.js
+++ b/src/scripts/widget.js
@@ -81,15 +81,35 @@ angular.module('adf')
       if (definition) {
         // bind close function
         $scope.close = function() {
-          var column = $scope.col;
-          if (column) {
-            var index = column.widgets.indexOf(definition);
-            if (index >= 0) {
-              column.widgets.splice(index, 1);
-            }
-          }
-          $element.remove();
-        };
+              var deleteScope= $scope.$new();
+              var adfDeleteTemplatePath = adfTemplatePath + 'widget-delete.html';
+              if (definition.deleteTemplateUrl) {
+                adfEditTemplatePath = definition.deleteTemplateUrl;
+              }
+              var opts = {
+                scope: deleteScope,
+                templateUrl: adfDeleteTemplatePath,
+                backdrop: 'static'
+              };
+              var instance = $modal.open(opts);
+
+              deleteScope.closeDialog = function() {
+                instance.close();
+                deleteScope.$destroy();
+              };
+              deleteScope.deleteDialog = function() {
+                instance.close();
+                deleteScope.$destroy();
+                var column = $scope.col;
+                if (column) {
+                  var index = column.widgets.indexOf(definition);
+                  if (index >= 0) {
+                    column.widgets.splice(index, 1);
+                  }
+                }
+                $element.remove();
+              };
+        }
 
         // bind reload function
         $scope.reload = function(){

--- a/src/templates/widget-delete.html
+++ b/src/templates/widget-delete.html
@@ -1,0 +1,14 @@
+<div class="modal-header">
+  <h4 class="modal-title">Delete {{widget.title}}</h4>
+</div>
+<div class="modal-body">
+  <form role="form">
+    <div class="form-group">
+      <label for="widgetTitle">Are you sure you want to delete this widget ?</label>
+    </div>
+  </form>
+</div>
+<div class="modal-footer">
+  <button type="button" class="btn btn-default" ng-click="closeDialog()">Close</button>
+  <button type="button" class="btn btn-primary" ng-click="deleteDialog()">Delete</button>
+</div>

--- a/src/templates/widget-title.html
+++ b/src/templates/widget-title.html
@@ -24,7 +24,7 @@
      <i class="glyphicon glyphicon-fullscreen"></i>
     </a>
     <!-- remove widget -->
-    <a href="" title="remove widget" ng-click="close()" ng-if="editMode">
+    <a href="" title="remove widget" ng-click="remove()" ng-if="editMode">
       <i class="glyphicon glyphicon-remove"></i>
     </a>
   </span>


### PR DESCRIPTION
Added new delete widget to adf,which prompts user modal popup before he deletes.

    $scope.close = function() {
    var deleteScope= $scope.$new();
    var adfDeleteTemplatePath = adfTemplatePath + 'widget-delete.html';
    if (definition.deleteTemplateUrl) {
    adfEditTemplatePath = definition.deleteTemplateUrl;
    }
     var opts = {
     scope: deleteScope,
    templateUrl: adfDeleteTemplatePath,
    backdrop: 'static'
    };
    var instance = $modal.open(opts);

              deleteScope.closeDialog = function() {
                instance.close();
                deleteScope.$destroy();
              };
              deleteScope.deleteDialog = function() {
                instance.close();
                deleteScope.$destroy();
                var column = $scope.col;
                if (column) {
                  var index = column.widgets.indexOf(definition);
                  if (index >= 0) {
                    column.widgets.splice(index, 1);
                  }
                }
                $element.remove();
              };
        }