### PR TITLE
Apply default configuration from widget definition

### DIFF
--- a/src/scripts/widget.js
+++ b/src/scripts/widget.js
@@ -59,6 +59,9 @@ angular.module('adf')
             config = {};
           }
 
+          // apply default configs
+          config = angular.extend(w.config || {}, config);
+
           // pass config to scope
           $scope.config = config;
 


### PR DESCRIPTION
I had to add this line to enable apply widget's default config. It was not working as appears in documentation.