### PR TITLE
Edit widget cancel shouldn't cause the 'widgetConfigChanged' event

### DIFF
--- a/src/scripts/widget.js
+++ b/src/scripts/widget.js
@@ -151,16 +151,15 @@ angular.module('adf')
           editScope.closeDialog = function() {
             instance.close();
             editScope.$destroy();
-
-            var widget = $scope.widget;
-            if (widget.edit && widget.edit.reload) {
-              // reload content after edit dialog is closed
-              $scope.$broadcast('widgetConfigChanged');
-            }
           };
           editScope.saveDialog = function() {
             definition.title = editScope.definition.title;
             angular.extend(definition.config, editScope.definition.config);
+            var widget = $scope.widget;
+            if (widget.edit && widget.edit.reload) {
+                // reload content after edit dialog is closed
+                $scope.$broadcast('widgetConfigChanged');
+            }
             editScope.closeDialog();
           };
         };


### PR DESCRIPTION
I think that widgetConfigChanged should be broadcasted only when Apply was clicked in edit widget mode. Currently a lot of unnecessary refreshing is happening when cancel is clicked. It's also consistent with how the whole dashboard edit mode behaves - the 'adfDashboardChanged' is only happening when 'save changes' is clicked, it's not happening when 'undo changes' is clicked.